### PR TITLE
Add observation-portal navbar link and API docs page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,8 @@
 - name: API Documentation
   link: /api/
   dropdown:
+    - name: Observation Portal
+      link: /api/observation_portal
     - name: Configuration Database
       link: /api/configdb/
     - name: Downtime Database

--- a/api/observation_portal.md
+++ b/api/observation_portal.md
@@ -1,0 +1,6 @@
+---
+layout: page
+title: Observation Portal API
+---
+
+{% include api.html url="/assets/html/observation-portal.html" %}


### PR DESCRIPTION
This adds an include of the HTML docs and a link in the navbar - tested locally, works great!

The new HTML page has been pushed since I merged to main in the observation-portal repo.